### PR TITLE
Add Linux support

### DIFF
--- a/Box2dNet/Box2dNet.csproj
+++ b/Box2dNet/Box2dNet.csproj
@@ -27,6 +27,8 @@
 	<ItemGroup>
 		<None Include="box2d.dll" Pack="true" PackagePath="runtimes/win-x64/native" CopyToOutputDirectory="PreserveNewest" />
 		<None Include="box2dd.dll" Pack="true" PackagePath="runtimes/win-x64/native" CopyToOutputDirectory="PreserveNewest" />
+		<None Include="libbox2d.so" Pack="true" PackagePath="runtimes/linux-x64/native" CopyToOutputDirectory="PreserveNewest" />
+		<None Include="libbox2dd.so" Pack="true" PackagePath="runtimes/linux-x64/native" CopyToOutputDirectory="PreserveNewest" />
 	</ItemGroup>
 
 </Project>

--- a/Box2dNetGen/Box2dNetGen/CsGenerator.cs
+++ b/Box2dNetGen/Box2dNetGen/CsGenerator.cs
@@ -87,9 +87,9 @@ namespace Box2dNet.Interop
 public static partial class B2Api
     {
 #if DEBUG
-        private const string Box2DLibrary = ""box2dd.dll"";
+        private const string Box2DLibrary = ""box2dd"";
 #else
-        private const string Box2DLibrary = ""box2d.dll"";
+        private const string Box2DLibrary = ""box2d"";
 #endif
 ");
         }

--- a/Box2dNetGen/Box2dNetGen/Program.cs
+++ b/Box2dNetGen/Box2dNetGen/Program.cs
@@ -63,7 +63,7 @@ namespace Box2dNetGen
 
             var box2dFolder = args[0];
             var outputFile = args[1];
-            if (Directory.Exists(Path.Combine(box2dFolder, "include\\box2d")) && File.Exists(Path.Combine(box2dFolder, "README.md")))
+            if (Directory.Exists(Path.Combine(box2dFolder, "include", "box2d")) && File.Exists(Path.Combine(box2dFolder, "README.md")))
             {
                 await BuildCsWrapperAsync(box2dFolder, outputFile);
                 Console.WriteLine();
@@ -77,7 +77,7 @@ namespace Box2dNetGen
 
         private static async Task BuildCsWrapperAsync(string box2dFolder, string csFilename)
         {
-            var src = await ReadSourceFiles(Path.Combine(box2dFolder, "include\\box2d"));
+            var src = await ReadSourceFiles(Path.Combine(box2dFolder, "include", "box2d"));
 
             Console.WriteLine("\n\nParsing C ...");
             var constants = ConstantsExtractor.ExtractAllPrecompilerDefines(_precompilerConstantsIgnoreList, src).ToList();


### PR DESCRIPTION
C# may be cross-platform, but the underlying binaries are not. These changes remove platform-specific "phrasing", enabling the same steps for users to build the solution and package the binaries out of the box on linux