### PR TITLE
Add generation of span and function pointer overloads

### DIFF
--- a/Box2dNet.OldSamples/Box2dNet.OldSamples.csproj
+++ b/Box2dNet.OldSamples/Box2dNet.OldSamples.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/Box2dNet.Samples/Box2dNet.Samples.csproj
+++ b/Box2dNet.Samples/Box2dNet.Samples.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/Box2dNet/Box2dNet.csproj
+++ b/Box2dNet/Box2dNet.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net10.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<AllowUnsafeBlocks>True</AllowUnsafeBlocks>

--- a/Box2dNetGen/Box2dNetGen/Box2dNetGen.csproj
+++ b/Box2dNetGen/Box2dNetGen/Box2dNetGen.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/Box2dNetGen/Box2dNetGen/Extensions.cs
+++ b/Box2dNetGen/Box2dNetGen/Extensions.cs
@@ -1,0 +1,4 @@
+public static class Extensions
+{
+    public static string ToCsv<T>(this IEnumerable<T> items, string separator = ", ") => string.Join(separator, items);
+}

--- a/Box2dNetGen/Box2dNetGen/Generators/CommentGenerator.cs
+++ b/Box2dNetGen/Box2dNetGen/Generators/CommentGenerator.cs
@@ -7,7 +7,39 @@ namespace Box2dNetGen.Generators
     {
         private static Regex ParameterRegex = new("@param\\s+(?<identifier>\\S+)\\s+(?<description>.*)");
 
-        public static void AppendComment(StringBuilder sb, List<string> comment, string? returnType, Dictionary<string, string>? extraParameterComments = null)
+        public static void AppendComment(StringBuilder sb, List<string> comment, string? returnType,
+            Dictionary<string, string>? extraParameterComments = null)
+        {
+            Dictionary<string, string> originalParameterComments = OriginalParameterComments(sb, comment, returnType);
+
+            AppendParameterComments(sb, originalParameterComments, extraParameterComments); // if any...
+        }
+
+        public static void AppendOverloadComment(StringBuilder sb, List<string> comments, string? returnType,
+            Dictionary<string, string> identifierToOriginalIdentifiers)
+        {
+            Dictionary<string, string> originalParameterComments = OriginalParameterComments(sb, comments, returnType);
+
+            var parameterIdentifiers = originalParameterComments.Keys.ToList();
+            parameterIdentifiers.AddRange(identifierToOriginalIdentifiers.Keys);
+
+            foreach (var parameter in parameterIdentifiers)
+            {
+                var parameterCommentLines = new List<string>();
+                if (originalParameterComments.TryGetValue(parameter, out var originalComment))
+                    parameterCommentLines.Add(originalComment);
+                if (identifierToOriginalIdentifiers.TryGetValue(parameter, out var extraComments))
+                {
+                    parameterCommentLines.Add(extraComments);
+                }
+
+                sb.AppendLine(
+                    $"  /// <param name=\"{parameter}\">{string.Join("\r\n  /// ", parameterCommentLines)}</param>");
+            }
+        }
+
+        static Dictionary<string, string> OriginalParameterComments(StringBuilder sb, List<string> comment,
+            string? returnType)
         {
             var originalParameterComments = new Dictionary<string, string>();
             if (comment.Count > 0)
@@ -18,23 +50,25 @@ namespace Box2dNetGen.Generators
                     var parameterMatch = ParameterRegex.Match(s);
                     if (parameterMatch.Success)
                     {
-                        originalParameterComments.Add(parameterMatch.Groups["identifier"].Value, parameterMatch.Groups["description"].Value);
+                        originalParameterComments.Add(parameterMatch.Groups["identifier"].Value,
+                            parameterMatch.Groups["description"].Value);
                     }
                     else
                     {
                         sb.AppendLine("  /// " + s);
                     }
                 }
+
                 sb.AppendLine("  /// </summary>");
             }
 
             if (!string.IsNullOrWhiteSpace(returnType))
                 sb.AppendLine($"  /// <returns>Original C type: {returnType}</returns>");
-
-            AppendParameterComments(sb, originalParameterComments, extraParameterComments); // if any...
+            return originalParameterComments;
         }
 
-        private static void AppendParameterComments(StringBuilder sb, Dictionary<string, string> originalParameterComments,
+        private static void AppendParameterComments(StringBuilder sb,
+            Dictionary<string, string> originalParameterComments,
             Dictionary<string, string>? extraParameterComments)
         {
             var parameterIdentifiers = originalParameterComments.Keys.ToList();
@@ -44,9 +78,11 @@ namespace Box2dNetGen.Generators
                 var parameterCommentLines = new List<string>();
                 if (originalParameterComments.TryGetValue(parameter, out var originalComment))
                     parameterCommentLines.Add(originalComment);
-                if (extraParameterComments != null && extraParameterComments.TryGetValue(parameter, out var extraComment))
+                if (extraParameterComments != null
+                    && extraParameterComments.TryGetValue(parameter, out var extraComment))
                     parameterCommentLines.Add(extraComment);
-                sb.AppendLine($"  /// <param name=\"{parameter}\">{string.Join("\r\n  /// ", parameterCommentLines)}</param>");
+                sb.AppendLine(
+                    $"  /// <param name=\"{parameter}\">{string.Join("\r\n  /// ", parameterCommentLines)}</param>");
             }
         }
     }

--- a/Box2dNetGen/Box2dNetGen/Generators/DelegatesGenerator.cs
+++ b/Box2dNetGen/Box2dNetGen/Generators/DelegatesGenerator.cs
@@ -17,7 +17,7 @@ namespace Box2dNetGen.Generators
                     var parameters = utils.GenerateParameterList(apiDelegate.Parameters, true, true, out _);
                     sb.AppendLine("  [UnmanagedFunctionPointer(CallingConvention.Cdecl)]");
                     sb.AppendLine(
-                        $"  public delegate {typeMapper.MapType(apiDelegate.ReturnType, false, CodeDirection.ClrToNative, true, out _)} {apiDelegate.Identifier}({parameters});");
+                        $"  public delegate {typeMapper.MapType(apiDelegate.ReturnType, false, CodeDirection.ClrToNative, true, out _, out _)} {apiDelegate.Identifier}({parameters});");
                     cnt++;
                 }
                 catch (NoGenException e)

--- a/Box2dNetGen/Box2dNetGen/Generators/FunctionsGenerator.cs
+++ b/Box2dNetGen/Box2dNetGen/Generators/FunctionsGenerator.cs
@@ -14,39 +14,149 @@ namespace Box2dNetGen.Generators
                 try
                 {
                     var sbI = new StringBuilder();
-                    var parameters = utils.GenerateParameterList(apiFunction.Parameters, true, true, out var containsDelegateParameters);
+
+                    var parameters = utils.GenerateMappedParameterList(apiFunction.Parameters);
+                    var returnSymbol = typeMapper.MapType(apiFunction.ReturnType, false, CodeDirection.ClrToNative,
+                        true, out _, out _);
+
+                    var unsafeModifier = parameters.Any(x => x.SubParameters.Any(y => y.IsUnsafe))
+                        ? "unsafe "
+                        : string.Empty;
+
                     sbI.AppendLine();
-                    CommentGenerator.AppendComment(sbI, apiFunction.Comment, apiFunction.ReturnType, apiFunction.Parameters.ToDictionary(p => p.Identifier, p => $"(Original C type: {p.Type})"));
-                    sbI.AppendLine($"[DllImport(Box2DLibrary, CallingConvention = CallingConvention.Cdecl)]");
+                    CommentGenerator.AppendComment(sbI, apiFunction.Comment, apiFunction.ReturnType,
+                        apiFunction.Parameters.ToDictionary(p => p.Identifier, p => $"(Original C type: {p.Type})"));
+                    sbI.AppendLine("[DllImport(Box2DLibrary, CallingConvention = CallingConvention.Cdecl)]");
                     sbI.AppendLine(
-                        $"public static extern {typeMapper.MapType(apiFunction.ReturnType, false, CodeDirection.ClrToNative, true, out _)} {apiFunction.Identifier}({parameters});");
+                        $"public static extern {unsafeModifier}{returnSymbol} {apiFunction.Identifier}({parameters.ToCsv()});");
 
-                    if (containsDelegateParameters)
+                    // generate overloads
+                    for (int i = 0; i < parameters.Count; i++)
                     {
-                        // also generate C# overload that accepts the strongly typed delegate instead of IntPtr.
-                        sbI.AppendLine();
-                        parameters = utils.GenerateParameterList(apiFunction.Parameters, false, false, out _);
-                        var arguments = utils.GenerateArgumentList(apiFunction.Parameters);
-                        CommentGenerator.AppendComment(sbI, apiFunction.Comment, apiFunction.ReturnType, apiFunction.Parameters.ToDictionary(p => p.Identifier, p => $"(Original C type: {p.Type})"));
-                        sbI.AppendLine(
-                            $"public static {typeMapper.MapType(apiFunction.ReturnType, false, CodeDirection.ClrToNative, true, out _)} {apiFunction.Identifier}({parameters})");
-                        var @return = apiFunction.ReturnType != "void" ? "return " : "";
-                        sbI.AppendLine(
-                            $"{{\r\n    {@return}{apiFunction.Identifier}({arguments});\r\n}}");
+                        var param = parameters[i];
+                        if (param.AltParameters.Count == 0) continue;
 
+
+                        MainParameter[] previousElements = parameters.Slice(0, i).ToArray();
+                        MainParameter[] nextElements = parameters.Slice(i + 1, parameters.Count - (i + 1)).ToArray();
+
+
+                        foreach (var altParameter in param.AltParameters)
+                        {
+                            var isUnsafeAlt = altParameter.ParamAndArgs.All(x => x.Parameter.IsUnsafe) ||
+                                              previousElements.Any(x => x.SubParameters.Any(y => y.IsUnsafe)) ||
+                                              nextElements.Any(x => x.SubParameters.Any(y => y.IsUnsafe));
+
+                            var commentDict = previousElements.Concat(nextElements)
+                                .SelectMany(x => x.SubParameters)
+                                .ToDictionary(p => p.Identifier,
+                                    p => $"(Original C type: {p.Type})");
+
+                            foreach (var paramAndArg in altParameter.ParamAndArgs)
+                            {
+                                if (paramAndArg.RepresentsApiParameters.Count == 1)
+                                {
+                                    commentDict.Add(paramAndArg.Parameter.Identifier,
+                                        paramAndArg.RepresentsApiParameters.Select(x => $"(Original C type: {x.Type})")
+                                            .First());
+                                }
+                                else
+                                {
+                                    var commentStr = "Original parameters: " + string.Join("; ",
+                                        paramAndArg.RepresentsApiParameters.Select(x =>
+                                            $"\"{x.Identifier}\" (original C type: {x.Type})"));
+                                    commentDict.Add(paramAndArg.Parameter.Identifier, commentStr);
+                                }
+                            }
+
+                            sbI.AppendLine();
+                            CommentGenerator.AppendOverloadComment(sbI, apiFunction.Comment, apiFunction.ReturnType,
+                                commentDict);
+
+                            if (altParameter.IsAlsoExtern)
+                            {
+                                sbI.AppendLine(
+                                    "[DllImport(Box2DLibrary, CallingConvention = CallingConvention.Cdecl)]");
+                            }
+
+                            var externModifier = altParameter.IsAlsoExtern ? "extern " : string.Empty;
+                            var externEnd = altParameter.IsAlsoExtern ? ";" : string.Empty;
+                            var unsafeModifierAlt = isUnsafeAlt ? "unsafe " : string.Empty;
+
+
+                            var overloadParameterSelect = previousElements.SelectMany(x => x.SubParameters)
+                                .Concat(altParameter.ParamAndArgs.Select(x => x.Parameter))
+                                .Concat(nextElements.SelectMany(x => x.SubParameters));
+
+                            sbI.AppendLine(
+                                $"public static {externModifier}{unsafeModifierAlt}{returnSymbol} {apiFunction.Identifier}({overloadParameterSelect.ToCsv()}){externEnd}");
+
+                            if (!altParameter.IsAlsoExtern)
+                            {
+                                sbI.AppendLine("{");
+                                int indentLevel = 1;
+
+                                foreach (var paramAndArg in altParameter.ParamAndArgs)
+                                {
+                                    bool useWrap = paramAndArg.CallWrap.HasValue;
+                                    if (useWrap)
+                                    {
+                                        AppendIndent(sbI, indentLevel);
+                                        sbI.AppendLine(paramAndArg.GetPreCallStr());
+                                    }
+
+                                    if (useWrap && paramAndArg.CallWrap!.Value.IncrementScope)
+                                    {
+                                        AppendIndent(sbI, indentLevel);
+                                        sbI.AppendLine("{");
+                                        indentLevel++;
+                                    }
+                                }
+
+                                var argSelect = previousElements.SelectMany(x => x.SubParameters)
+                                    .Select(x => x.Identifier)
+                                    .Concat([altParameter.ToArgString()])
+                                    .Concat(nextElements.SelectMany(x => x.SubParameters).Select(x => x.Identifier));
+
+                                AppendIndent(sbI, indentLevel);
+                                sbI.AppendLine(
+                                    $"{(returnSymbol == "void" ? "" : "return ")}{apiFunction.Identifier}({argSelect.ToCsv()});");
+                                altParameter.ToArgString();
+
+                                foreach (var paramAndArg in altParameter.ParamAndArgs)
+                                {
+                                    if (paramAndArg.CallWrap?.IncrementScope ?? false)
+                                    {
+                                        indentLevel--;
+                                        AppendIndent(sbI, indentLevel);
+                                        sbI.AppendLine("}");
+                                    }
+                                }
+
+                                sbI.AppendLine("}");
+                            }
+                        }
                     }
 
-                    sb.Append(sbI.ToString()); // commit
+                    sb.Append(sbI); // commit
                     cnt++;
                 }
                 catch (NoGenException e)
                 {
                     Console.WriteLine($"WARNING: skipping function '{apiFunction.Identifier}' because: {e.Message}");
-                    ;
                 }
             }
 
             return cnt;
+        }
+
+        private static void AppendIndent(StringBuilder sb, int indentLevel)
+        {
+            const string indent = "    ";
+            for (int i = 0; i < indentLevel; i++)
+            {
+                sb.Append(indent);
+            }
         }
     }
 }

--- a/Box2dNetGen/Box2dNetGen/Generators/FunctionsGenerator.cs
+++ b/Box2dNetGen/Box2dNetGen/Generators/FunctionsGenerator.cs
@@ -113,10 +113,9 @@ namespace Box2dNetGen.Generators
                                     }
                                 }
 
-                                var argSelect = previousElements.SelectMany(x => x.SubParameters)
-                                    .Select(x => x.Identifier)
+                                var argSelect = previousElements.SelectMany(x => x.SubParameters).Select(IdentifierWithModifier)
                                     .Concat([altParameter.ToArgString()])
-                                    .Concat(nextElements.SelectMany(x => x.SubParameters).Select(x => x.Identifier));
+                                    .Concat(nextElements.SelectMany(x => x.SubParameters).Select(IdentifierWithModifier));
 
                                 AppendIndent(sbI, indentLevel);
                                 sbI.AppendLine(
@@ -149,7 +148,6 @@ namespace Box2dNetGen.Generators
 
             return cnt;
         }
-
         private static void AppendIndent(StringBuilder sb, int indentLevel)
         {
             const string indent = "    ";
@@ -157,6 +155,17 @@ namespace Box2dNetGen.Generators
             {
                 sb.Append(indent);
             }
+        }
+        static string IdentifierWithModifier(MappedParameter x)
+        {
+            string modifier = x.Type switch
+            {
+                _ when x.Type.StartsWith("in ") => "in ",
+                _ when x.Type.StartsWith("ref ") => "ref ",
+                _ when x.Type.StartsWith("out ") => "out ",
+                _ => string.Empty
+            };
+            return $"{modifier}{x.Identifier}";
         }
     }
 }

--- a/Box2dNetGen/Box2dNetGen/Generators/GeneratorUtils.cs
+++ b/Box2dNetGen/Box2dNetGen/Generators/GeneratorUtils.cs
@@ -5,7 +5,8 @@
         /// <summary>
         /// Generates a list of parameters for a function.
         /// </summary>
-        public string GenerateParameterList(List<ApiParameter> parameters, bool includeMarshalAttributes, bool delegateAsIntPtr, out bool containsDelegateParameters)
+        public string GenerateParameterList(List<ApiParameter> parameters, bool includeMarshalAttributes,
+            bool delegateAsIntPtr, out bool containsDelegateParameters)
         {
             containsDelegateParameters = false;
             var csParameters = new List<string>();
@@ -13,15 +14,20 @@
             {
                 var p = parameters[i];
                 var nextParameterIdentifier = i < parameters.Count - 1 ? parameters[i + 1].Identifier : "";
+                // naive but seems to work for box2d: when a pointer parameter is followed by a 'count' parameter, it's an array, else it's a ptr to a single item.
                 var isArray = p.Type.EndsWith("*") &&
-                              (p.Identifier.ToLower().EndsWith("array") || nextParameterIdentifier.ToLower().Contains("count") || nextParameterIdentifier.ToLower().Contains("capacity")); // naive but seems to work for box2d: when a pointer parameter is followed by a 'count' parameter, it's an array, else it's a ptr to a single item.
+                              (p.Identifier.EndsWith("array", StringComparison.OrdinalIgnoreCase) ||
+                               nextParameterIdentifier.Contains("count", StringComparison.OrdinalIgnoreCase) ||
+                               nextParameterIdentifier.Contains("capacity", StringComparison.OrdinalIgnoreCase));
                 var attribute = "";
                 if (includeMarshalAttributes)
                     attribute = (p.Type == "bool") ? "[MarshalAs(UnmanagedType.U1)] " : "";
-                csParameters.Add($"{attribute}{typeMapper.MapType(p.Type, !isArray, CodeDirection.ClrToNative, delegateAsIntPtr, out var isDelegate)} {p.Identifier}");
+                csParameters.Add(
+                    $"{attribute}{typeMapper.MapType(p.Type, !isArray, CodeDirection.ClrToNative, delegateAsIntPtr, out var isDelegate, out _)} {p.Identifier}");
                 if (isDelegate)
                     containsDelegateParameters = true;
             }
+
             return string.Join(", ", csParameters);
         }
 
@@ -35,9 +41,12 @@
             {
                 var p = parameters[i];
                 var nextParameterIdentifier = i < parameters.Count - 1 ? parameters[i + 1].Identifier : "";
-                var isArray = p.Type.EndsWith("*") &&
-                              (p.Identifier.ToLower().EndsWith("array") || nextParameterIdentifier.ToLower().Contains("count") || nextParameterIdentifier.ToLower().Contains("capacity")); // naive but seems to work for box2d: when a pointer parameter is followed by a 'count' parameter, it's an array, else it's a ptr to a single item.
-                typeMapper.MapType(p.Type, !isArray, CodeDirection.ClrToNative, false, out var isDelegate);
+                // naive but seems to work for box2d: when a pointer parameter is followed by a 'count' parameter, it's an array, else it's a ptr to a single item.
+                var isArray = p.Type.EndsWith('*') &&
+                              (p.Identifier.EndsWith("array", StringComparison.OrdinalIgnoreCase) ||
+                               nextParameterIdentifier.Contains("count", StringComparison.OrdinalIgnoreCase) ||
+                               nextParameterIdentifier.Contains("capacity", StringComparison.OrdinalIgnoreCase));
+                typeMapper.MapType(p.Type, !isArray, CodeDirection.ClrToNative, false, out var isDelegate, out _);
                 if (isDelegate)
                 {
                     csArguments.Add($"Marshal.GetFunctionPointerForDelegate({p.Identifier})");
@@ -47,7 +56,50 @@
                     csArguments.Add($"{p.Identifier}");
                 }
             }
+
             return string.Join(", ", csArguments);
+        }
+
+        /// <summary>
+        /// Generates a list of parameters for a function.
+        /// </summary>
+        public List<MainParameter> GenerateMappedParameterList(List<ApiParameter> parameters)
+        {
+            var csParameters = new List<MainParameter>();
+            for (var i = 0; i < parameters.Count; i++)
+            {
+                List<MappedParameter> mappedParameters = [];
+                List<AltParameter> altParameters = [];
+
+                var p = parameters[i];
+                var nextParameterIdentifier = i < parameters.Count - 1 ? parameters[i + 1].Identifier : "";
+                // naive but seems to work for box2d: when a pointer parameter is followed by a 'count' parameter, it's an array, else it's a ptr to a single item.
+                var isArray = p.Type.EndsWith('*') &&
+                              (p.Identifier.EndsWith("array", StringComparison.OrdinalIgnoreCase) ||
+                               nextParameterIdentifier.Contains("count", StringComparison.OrdinalIgnoreCase) ||
+                               nextParameterIdentifier.Contains("capacity", StringComparison.OrdinalIgnoreCase));
+
+                var mainParam = typeMapper.MapParameter(p, !isArray);
+                mappedParameters.Add(mainParam);
+
+                if (isArray)
+                {
+                    i++; // skip the 'count' parameter - combine it into this one
+
+                    var p2 = parameters[i];
+                    var capacityParam = typeMapper.MapParameter(p2, !isArray);
+                    mappedParameters.Add(capacityParam);
+                }
+
+                if (mainParam.HasAlternativeForm)
+                {
+                    altParameters.AddRange(typeMapper.MapAlternativeTypes(p, isArray ? parameters[i] : null));
+                }
+
+                csParameters.Add(new MainParameter(mappedParameters, altParameters));
+            }
+
+            return csParameters;
         }
     }
 }

--- a/Box2dNetGen/Box2dNetGen/Generators/StructsGenerator.cs
+++ b/Box2dNetGen/Box2dNetGen/Generators/StructsGenerator.cs
@@ -28,7 +28,7 @@ namespace Box2dNetGen.Generators
                     {
                         sbI.AppendLine();
                         CommentGenerator.AppendComment(sbI, field.Comment, field.Type);
-                        var clrType = typeMapper.MapType(field.Type, false, CodeDirection.NativeToClr, true, out _);
+                        var clrType = typeMapper.MapType(field.Type, false, CodeDirection.NativeToClr, true, out _, out _);
                         if (field.IsFixedArray)
                         {
                             structHasNoArrayFields = false;

--- a/Box2dNetGen/Box2dNetGen/Generators/TypeMapper.cs
+++ b/Box2dNetGen/Box2dNetGen/Generators/TypeMapper.cs
@@ -13,6 +13,7 @@ namespace Box2dNetGen.Generators
         {
             var typeStr = MapType(p.Type, isNotArray, CodeDirection.ClrToNative, true, out bool hasAlternativeform,
                 out bool isUnsafe);
+
             return new MappedParameter(typeStr, p.Identifier, isUnsafe, hasAlternativeform,
                 p.Type == "bool" ? "[MarshalAs(UnmanagedType.U1)] " : string.Empty);
         }
@@ -159,7 +160,8 @@ namespace Box2dNetGen.Generators
                 var fnPointerType = $"delegate* unmanaged[Cdecl]<{string.Join(", ", parameterSelect)}, {returnValue}>";
 
                 yield return new AltParameter([
-                    new ParamAndArg(new MappedParameter(fnPointerType, parameter.Identifier, true), [parameter], "(IntPtr){0}")
+                    new ParamAndArg(new MappedParameter(fnPointerType, parameter.Identifier, true), [parameter],
+                        "(IntPtr){0}")
                 ]);
 
                 yield break;

--- a/Box2dNetGen/Box2dNetGen/Generators/TypeMapper.cs
+++ b/Box2dNetGen/Box2dNetGen/Generators/TypeMapper.cs
@@ -1,4 +1,6 @@
-﻿namespace Box2dNetGen.Generators
+﻿using System.Data;
+
+namespace Box2dNetGen.Generators
 {
     internal class TypeMapper(
         Dictionary<string, string> structTypeReplacer,
@@ -7,10 +9,21 @@
         Dictionary<string, ApiDelegate> delegates,
         HashSet<string> excludedTypes)
     {
-        /// <param name="isNotArray">Only relevant when the type is a pointer. Else ignored.</param>
-        public string MapType(in string cType, bool isNotArray, CodeDirection codeDirection, bool returnDelegateAsIntPtr, out bool isDelegate)
+        public MappedParameter MapParameter(ApiParameter p, bool isNotArray)
         {
-            isDelegate = false;
+            var typeStr = MapType(p.Type, isNotArray, CodeDirection.ClrToNative, true, out bool hasAlternativeform,
+                out bool isUnsafe);
+            return new MappedParameter(typeStr, p.Identifier, isUnsafe, hasAlternativeform,
+                p.Type == "bool" ? "[MarshalAs(UnmanagedType.U1)] " : string.Empty);
+        }
+
+        /// <param name="isNotArray">Only relevant when the type is a pointer. Else ignored.</param>
+        public string MapType(in string cType, bool isNotArray, CodeDirection codeDirection,
+            bool returnDelegateAsIntPtr, out bool hasAlternativeform, out bool isUnsafe)
+        {
+            hasAlternativeform = !isNotArray;
+            isUnsafe = false;
+
             var type = RemoveSpaces(cType);
             var isConst = false;
             if (type.StartsWith("const"))
@@ -18,7 +31,8 @@
                 isConst = true;
                 type = type[5..];
             }
-            var isPointer = type.EndsWith("*");
+
+            var isPointer = type.EndsWith('*');
             if (isPointer) type = type.TrimEnd('*');
 
             // check intrinsic types:
@@ -59,17 +73,23 @@
             // type is a enum?
             if (enums.TryGetValue(type, out var apiEnum))
             {
-                if (isPointer) throw new Exception($"Used type seems to be enum '{apiEnum.Identifier}' but it's a pointer, which is suspicious in C.");
+                if (isPointer)
+                    throw new Exception(
+                        $"Used type seems to be enum '{apiEnum.Identifier}' but it's a pointer, which is suspicious in C.");
                 return apiEnum.Identifier;
             }
 
             // type is a delegate?
             if (delegates.TryGetValue(type, out var apiDelegate))
             {
-                if (!isPointer) throw new Exception($"Used type seems to be delegate '{apiDelegate.Identifier}' but it's not a pointer, which is invalid C.");
-                isDelegate = true;
+                if (!isPointer)
+                    throw new Exception(
+                        $"Used type seems to be delegate '{apiDelegate.Identifier}' but it's not a pointer, which is invalid C.");
+                hasAlternativeform = true;
                 if (returnDelegateAsIntPtr)
                     return $"IntPtr";
+
+                isUnsafe = true;
                 return type;
             }
 
@@ -93,9 +113,11 @@
                     }
 
                     if (codeDirection == CodeDirection.NativeToClr)
-                        return "IntPtr"; // 'returning' arrays won't allocate .NET arrays. We have to accept the array as an IntPtr and loop over it. See helper method NativeArrayAsSpan in Box2dNet.
+                        return
+                            "IntPtr"; // 'returning' arrays won't allocate .NET arrays. We have to accept the array as an IntPtr and loop over it. See helper method NativeArrayAsSpan in Box2dNet.
 
-                    return $"{type}[]";
+                    isUnsafe = true;
+                    return $"{type}*";
                 }
 
                 return type;
@@ -105,12 +127,88 @@
             {
                 throw new NoGenException($"Type '{cType}' is in the 'Excluded' list.");
             }
+
             throw new NoGenException($"No known mapping for type '{cType}'.");
+        }
+
+        public IEnumerable<AltParameter> MapAlternativeTypes(ApiParameter parameter,
+            ApiParameter? capacityParameter = null)
+        {
+            var type = RemoveSpaces(parameter.Type);
+            if (type.StartsWith("const"))
+                type = type[5..];
+
+            var isPointer = type.EndsWith('*');
+            if (isPointer) type = type.TrimEnd('*');
+
+            // type is a delegate?
+            if (delegates.TryGetValue(type, out var apiDelegate))
+            {
+                if (!isPointer)
+                    throw new Exception(
+                        $"Used type seems to be delegate '{apiDelegate.Identifier}' but it's not a pointer, which is invalid C.");
+
+                yield return new([
+                    new ParamAndArg(new MappedParameter(apiDelegate.Identifier, parameter.Identifier, false),
+                        [parameter], "Marshal.GetFunctionPointerForDelegate({0})")
+                ]);
+
+                var parameterSelect = apiDelegate.Parameters.Select(x =>
+                    MapType(x.Type, true, CodeDirection.ClrToNative, true, out _, out _));
+                var returnValue = MapType(apiDelegate.ReturnType, true, CodeDirection.NativeToClr, true, out _, out _);
+                var fnPointerType = $"delegate* unmanaged[Cdecl]<{string.Join(", ", parameterSelect)}, {returnValue}>";
+
+                yield return new AltParameter([
+                    new ParamAndArg(new MappedParameter(fnPointerType, parameter.Identifier, true), [parameter], "(IntPtr){0}")
+                ]);
+
+                yield break;
+            }
+
+            // type is a struct?
+            var isReplacedByDotNetStruct = false;
+            if (structTypeReplacer.TryGetValue(type, out var dotNetStruct))
+            {
+                type = dotNetStruct;
+                isReplacedByDotNetStruct = true;
+            }
+
+            var typeIsUserStruct = structs.ContainsKey(type); // it's a struct defined by Box2D code
+            if (typeIsUserStruct || isReplacedByDotNetStruct)
+            {
+                if (isPointer)
+                {
+                    var mappedCapacityParameter =
+                        MapParameter(
+                            capacityParameter ?? throw new InvalidOperationException(
+                                "Need capacity parameter passed in when mapping alternative array types"), false);
+                    yield return new([
+                        new ParamAndArg(new MappedParameter($"{type}[]", parameter.Identifier, false),
+                            [parameter], ArgConversionFormat: null),
+                        new ParamAndArg(mappedCapacityParameter, [capacityParameter], ArgConversionFormat: null)
+                    ]);
+
+                    CallWrap wrap = new($"fixed ({type}* arrayPtr = {{0}})");
+                    yield return new AltParameter([
+                        new ParamAndArg(
+                            new MappedParameter($"Span<{type}>", parameter.Identifier, true),
+                            [parameter, capacityParameter], "arrayPtr, {0}.Length", wrap)
+                    ]);
+                    yield break;
+                }
+            }
+
+            if (excludedTypes.Contains(type))
+            {
+                throw new NoGenException($"Type '{type}' is in the 'Excluded' list.");
+            }
+
+            throw new NoGenException($"No known mapping for type '{type}'.");
         }
 
         private static string RemoveSpaces(string src)
         {
-            return new string(src.Where(ch => ch != ' ').ToArray());
+            return src.Replace(" ", string.Empty);
         }
     }
 }

--- a/Box2dNetGen/Box2dNetGen/MappingStructures.cs
+++ b/Box2dNetGen/Box2dNetGen/MappingStructures.cs
@@ -1,0 +1,42 @@
+namespace Box2dNetGen;
+
+internal record MappedParameter(
+    string Type,
+    string Identifier,
+    bool IsUnsafe,
+    bool HasAlternativeForm = false,
+    string? Attribute = "")
+{
+    public override string ToString() => $"{Attribute}{Type} {Identifier}";
+}
+
+internal readonly record struct MainParameter(
+    List<MappedParameter> SubParameters,
+    List<AltParameter>? AltParameters = null)
+{
+    public override string ToString() => SubParameters.ToCsv();
+}
+
+internal record AltParameter(List<ParamAndArg> ParamAndArgs)
+{
+    public bool IsAlsoExtern => ParamAndArgs.All(x => x.ArgConversionFormat is null);
+
+    public string ToArgString() => ParamAndArgs.Select(x => x.ToArgString()).ToCsv();
+}
+
+internal record ParamAndArg(
+    MappedParameter Parameter,
+    List<ApiParameter> RepresentsApiParameters,
+    string? ArgConversionFormat = null,
+    CallWrap? CallWrap = null)
+{
+    public string ToArgString() =>
+        ArgConversionFormat is null ? Parameter.Identifier : string.Format(ArgConversionFormat, Parameter.Identifier);
+
+    public string GetPreCallStr() =>
+        CallWrap.HasValue
+            ? string.Format(CallWrap.Value.PreCallFormat, Parameter.Identifier)
+            : throw new InvalidOperationException();
+}
+
+internal readonly record struct CallWrap(string PreCallFormat, bool IncrementScope = true);


### PR DESCRIPTION
Adds support for generating more API function overloads, adding span and function pointer variants.

Spans:
Motivation - requiring a standard array requires copying data to an array if an array-like structure is used on the C#-side, such as a list or stack allocated span. Spans expose a generic zero-allocation interface, and can be safely used with underlying garbage collected structures (span over a regular array) when using `fixed` statements. [Docs](https://learn.microsoft.com/en-us/dotnet/api/system.span-1.getpinnablereference?view=netstandard-2.1#system-span-1-getpinnablereference).
Added raw pointer + count extern overloads to support the span-based ones.

Generated code looks like the following:

```cs
  /// <summary>
  /// Get the shape ids for all shapes on this body, up to the provided capacity.
  /// @returns the number of shape ids stored in the user array
  /// </summary>
  /// <returns>Original C type: int</returns>
  /// <param name="bodyId">(Original C type: b2BodyId)</param>
  /// <param name="shapeArray">(Original C type: b2ShapeId*)</param>
  /// <param name="capacity">(Original C type: int)</param>
[DllImport(Box2DLibrary, CallingConvention = CallingConvention.Cdecl)]
public static extern unsafe int b2Body_GetShapes(b2BodyId bodyId, b2ShapeId* shapeArray, int capacity);

  /// <summary>
  /// Get the shape ids for all shapes on this body, up to the provided capacity.
  /// @returns the number of shape ids stored in the user array
  /// </summary>
  /// <returns>Original C type: int</returns>
  /// <param name="bodyId">(Original C type: b2BodyId)</param>
  /// <param name="shapeArray">(Original C type: b2ShapeId*)</param>
  /// <param name="capacity">(Original C type: int)</param>
[DllImport(Box2DLibrary, CallingConvention = CallingConvention.Cdecl)]
public static extern int b2Body_GetShapes(b2BodyId bodyId, b2ShapeId[] shapeArray, int capacity);

  /// <summary>
  /// Get the shape ids for all shapes on this body, up to the provided capacity.
  /// @returns the number of shape ids stored in the user array
  /// </summary>
  /// <returns>Original C type: int</returns>
  /// <param name="bodyId">(Original C type: b2BodyId)</param>
  /// <param name="shapeArray">Original parameters: "shapeArray" (original C type: b2ShapeId*); "capacity" (original C type: int)</param>
public static unsafe int b2Body_GetShapes(b2BodyId bodyId, Span<b2ShapeId> shapeArray)
{
    fixed (b2ShapeId* arrayPtr = shapeArray)
    {
        return b2Body_GetShapes(bodyId, arrayPtr, shapeArray.Length);
    }
}
```

Function pointers:
Motivation - The delegate overloads instead of raw pointers add type-safety, but they introduce a non-zero amount of overhead due to overhead of delegates and `Marshal.GetFunctionPointerForDelegate`. dotnet 9.0 added function pointers, which are strongly-typed pointers which serve a similar function to `Marshal.GetFunctionPointerForDelegate`, but without the overhead of delegates. [Docs](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/unsafe-code#function-pointers)
Bumped the projects to dotnet 10.0 to support them

Generated code looks like the following:
```cs
  /// <summary>
  /// Override the default assert function
  /// </summary>
  /// <returns>Original C type: void</returns>
  /// <param name="assertFcn">a non-null assert callback
  /// (Original C type: b2AssertFcn*)</param>
  /// <param name="assertFcn">a non-null assert callback
  /// (Original C type: b2AssertFcn*)</param>
[DllImport(Box2DLibrary, CallingConvention = CallingConvention.Cdecl)]
public static extern void b2SetAssertFcn(IntPtr assertFcn);

  /// <summary>
  /// Override the default assert function
  /// </summary>
  /// <returns>Original C type: void</returns>
  /// <param name="assertFcn">a non-null assert callback
  /// (Original C type: b2AssertFcn*)</param>
  /// <param name="assertFcn">a non-null assert callback
  /// (Original C type: b2AssertFcn*)</param>
public static void b2SetAssertFcn(b2AssertFcn assertFcn)
{
    b2SetAssertFcn(Marshal.GetFunctionPointerForDelegate(assertFcn));
}

  /// <summary>
  /// Override the default assert function
  /// </summary>
  /// <returns>Original C type: void</returns>
  /// <param name="assertFcn">a non-null assert callback
  /// (Original C type: b2AssertFcn*)</param>
  /// <param name="assertFcn">a non-null assert callback
  /// (Original C type: b2AssertFcn*)</param>
public static unsafe void b2SetAssertFcn(delegate* unmanaged[Cdecl]<string, string, int, int> assertFcn)
{
    b2SetAssertFcn((IntPtr)assertFcn);
}
```

Note: I explicitly didn't regenerate the b2Api file, since there appears to be some box2d api changes I don't want to include and because idk big diff